### PR TITLE
fix copy paste bug

### DIFF
--- a/js/cmd-ref.json
+++ b/js/cmd-ref.json
@@ -73,7 +73,7 @@
   },
   "find": {
     "desc": "search for a file",
-    "keyBinding": [84, 65, 73, 76]
+    "keyBinding": [70, 73, 78, 68]
   },
   "tar": {
     "desc": "tape archive - read/write archives",


### PR DESCRIPTION
The key binding for "find" was the same as "tail". Fixed to: 70 [f], 73 [i], 78 [n], 68 [d].