### PR TITLE
Add jshint config & make small grammar edits to pass jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "esversion": 6,
+  "eqnull": true
+}

--- a/js/game.js
+++ b/js/game.js
@@ -75,6 +75,7 @@
       }
 
       function checkKey(e) {
+        if (finished) return;
         e = e || window.event;
         activeEntry.push(e.keyCode);
         $gameEntry.innerHTML += e.key;
@@ -112,6 +113,7 @@
   // Start Game and counter
 
   let started = false;
+  let finished = false;
 
   window.onkeydown = function() {
     if(!started) {
@@ -123,6 +125,7 @@
       var countdownTimer = setInterval(function() {
         counter--;
         if(counter <= 0) {
+          finished = true;
           document.body.classList += 'game-over';
           window.clearInterval(countdownTimer);
 

--- a/js/game.js
+++ b/js/game.js
@@ -69,13 +69,8 @@
         activeEntry = [];
       };
 
-<<<<<<< HEAD
       nextEntry();
-      
-=======
-      nextEntry()
 
->>>>>>> e50f1c475e02c614335edb3d9c5ae1b46564e421
       // for every keydown, check to see if the answer is complete yet, or if ctrl+c was clicked to skip it
 
       const newGameItem = function() {
@@ -83,11 +78,7 @@
         nextEntry();
       };
 
-<<<<<<< HEAD
       const checkKey = function(e) {
-=======
-      function checkKey(e) {
->>>>>>> e50f1c475e02c614335edb3d9c5ae1b46564e421
         if (finished) return;
         e = e || window.event;
         activeEntry.push(e.keyCode);

--- a/js/game.js
+++ b/js/game.js
@@ -57,24 +57,24 @@
       let currentPattern = '';
       let currentCmdName = '';
 
-      function nextEntry() {
+      const nextEntry = function() {
         let randomItem = dataArray[randomizeValue(data)];
         $gameDef.innerHTML = randomItem.desc;
         currentCmdName = randomItem.command;
         currentPattern = randomItem.keyBinding.join();
         activeEntry = [];
-      }
+      };
 
-      nextEntry()
+      nextEntry();
       
       // for every keydown, check to see if the answer is complete yet, or if ctrl+c was clicked to skip it
 
-      function newGameItem() {
+      const newGameItem = function() {
         $gameEntry.innerHTML = '';
         nextEntry();
-      }
+      };
 
-      function checkKey(e) {
+      const checkKey = function(e) {
         e = e || window.event;
         activeEntry.push(e.keyCode);
         $gameEntry.innerHTML += e.key;
@@ -102,7 +102,7 @@
 
           newGameItem();
         }
-      }
+      };
 
       // init keydown function
       document.onkeydown = checkKey;


### PR DESCRIPTION
Add .jshintrc configuration file to suppress two unwanted warnings: Using let / const es6 variable declarations. And using non-strict equality comparison (!=) to compare null in getJSON callback function.

Second commit simply updates code to pass jshint linting.
Jshint doesn't like named function declarations to be declared in blocks, but at the highest level of the outer function. So this commit refactors those three function declarations (all within getJSON callback) to use an anonymous function expression assigned to a const declared variable.